### PR TITLE
Webpack Debug With WebStorm

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,7 @@ var config = {
       }
     ]
   },
+  devtool: "source-map",
   devServer: {
     historyApiFallback: true,
     headers: { "Access-Control-Allow-Origin": "*" }


### PR DESCRIPTION
webpack.config.js has been updated to include devtool option of
which value is "source-map" to debug with webstorm.